### PR TITLE
split zapd into two targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ add_custom_target(
     # CMake versions prior to 3.17 do not have the rm command, use remove instead for older versions
     COMMAND ${CMAKE_COMMAND} -E $<IF:$<VERSION_LESS:${CMAKE_VERSION},3.17>,remove,rm> -f oot.otr oot-mq.otr soh.otr
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter/extract_assets.py -z "$<TARGET_FILE:ZAPD>" --non-interactive
-    COMMAND ${CMAKE_COMMAND} -DSYSTEM_NAME=${CMAKE_SYSTEM_NAME} -DTARGET_DIR="$<TARGET_FILE_DIR:soh>" -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/copy-existing-otrs.cmake
+    COMMAND ${CMAKE_COMMAND} -DSYSTEM_NAME=${CMAKE_SYSTEM_NAME} -DTARGET_DIR="$<TARGET_FILE_DIR:ZAPD>" -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/copy-existing-otrs.cmake
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/OTRExporter
     COMMENT "Running asset extraction..."
     DEPENDS ZAPD

--- a/ZAPDTR/ZAPD/CMakeLists.txt
+++ b/ZAPDTR/ZAPD/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PROJECT_NAME ZAPD)
+set(PROJECT_NAME ZAPDLib)
 
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
 #set(CMAKE_C_STANDARD 11 CACHE STRING "The C standard to use")
@@ -263,16 +263,15 @@ set(ALL_FILES
 
 add_library(${PROJECT_NAME} STATIC ${ALL_FILES})
 
-#if (NOT TARGET soh)
-#	add_library(${PROJECT_NAME} STATIC ${ALL_FILES})
-#else()
-#	add_executable(${PROJECT_NAME} ${ALL_FILES})
-#endif()
+add_executable(ZAPD ExecutableMain.cpp)
+target_link_libraries(ZAPD ${PROJECT_NAME})
 
+# set_target_properties(ZAPD PROPERTIES RUNTIME_OUTPUT_NAME ${PROJECT_NAME})
 
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 use_props(${PROJECT_NAME} "${CMAKE_CONFIGURATION_TYPES}" "${DEFAULT_CXX_PROPS}")
+use_props(ZAPD "${CMAKE_CONFIGURATION_TYPES}" "${DEFAULT_CXX_PROPS}")
 endif()
 ################################################################################
 # Includes for CMake from *.props
@@ -299,7 +298,8 @@ endif()
 # MSVC runtime library
 ################################################################################
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-	get_property(MSVC_RUNTIME_LIBRARY_DEFAULT TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY)
+foreach(ZTarget ${PROJECT_NAME} ZAPD)
+	get_property(MSVC_RUNTIME_LIBRARY_DEFAULT TARGET ${ZTarget} PROPERTY MSVC_RUNTIME_LIBRARY)
 	if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
 		string(CONCAT "MSVC_RUNTIME_LIBRARY_STR"
 			$<$<CONFIG:Debug>:
@@ -311,7 +311,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 			$<$<NOT:$<OR:$<CONFIG:Debug>,$<CONFIG:Release>>>:${MSVC_RUNTIME_LIBRARY_DEFAULT}>
 		)
 	endif()
-	set_target_properties(${PROJECT_NAME} PROPERTIES MSVC_RUNTIME_LIBRARY ${MSVC_RUNTIME_LIBRARY_STR})
+	set_target_properties(${ZTarget} PROPERTIES MSVC_RUNTIME_LIBRARY ${MSVC_RUNTIME_LIBRARY_STR})
+endforeach()
 endif()
 ################################################################################
 # Compile definitions
@@ -321,7 +322,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		target_compile_definitions(${PROJECT_NAME} PRIVATE
 			"_CRT_SECURE_NO_WARNINGS;"
 			"_MBCS"
-			
 			STORMLIB_NO_AUTO_LINK
 		)
 	elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x86")
@@ -411,11 +411,6 @@ if(MSVC)
             /DEBUG:FULL
         )
     endif()
-	if(ZAPD_LIB)
-		target_link_options(${PROJECT_NAME} PRIVATE
-		/DZAPD_AS_LIB
-		)
-	endif()
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")

--- a/ZAPDTR/ZAPD/ExecutableMain.cpp
+++ b/ZAPDTR/ZAPD/ExecutableMain.cpp
@@ -1,0 +1,6 @@
+
+extern "C" int zapd_main(int argc, char* argv[]);
+
+int main(int argc, char* argv[]) {
+    return zapd_main(argc, argv);
+}

--- a/ZAPDTR/ZAPD/Main.cpp
+++ b/ZAPDTR/ZAPD/Main.cpp
@@ -96,14 +96,7 @@ void ErrorHandler(int sig)
 }
 #endif
 
-#define ZAPD_AS_LIB
-#ifdef ZAPD_AS_LIB
-#define ZAPD_MAIN zapd_main
-#else
-#define ZAPD_MAIN main
-#endif
-
-extern "C" int ZAPD_MAIN(int argc, char* argv[])
+extern "C" int zapd_main(int argc, char* argv[])
 {
 	// Syntax: ZAPD.out [mode (btex/bovl/e)] (Arbritrary Number of Arguments)
 

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -18,7 +18,6 @@ set (BUILD_SHARED_LIBS OFF CACHE STRING "install/link shared instead of static l
 # Set target arch type if empty. Visual studio solution generator provides it.
 ################################################################################
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-	set (ZAPD_LIB BOOL ON)
 	if(NOT CMAKE_VS_PLATFORM_NAME)
 		set(CMAKE_VS_PLATFORM_NAME "x64")
 	endif()
@@ -95,6 +94,10 @@ endif()
 
 if (NOT TARGET ZAPDUtils)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPDUtils ${CMAKE_BINARY_DIR}/ZAPDUtils)
+endif()
+
+if (NOT TARGET ZAPDLib)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPD ${CMAKE_BINARY_DIR}/ZAPD)
 endif()
 
 set(PROJECT_NAME soh)
@@ -177,6 +180,15 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 # }}}
 
+# soh/Extractor {{{
+file(GLOB_RECURSE soh__Extractor RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    "soh/Extractor/*.c"
+    "soh/Extractor/*.cpp"
+    "soh/Extractor/*.h"
+    "soh/Extractor/*.hpp"
+)
+# }}}
+
 # soh/resource {{{
 file(GLOB_RECURSE soh__Resource RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "soh/resource/*.cpp" "soh/resource/*.h")
 
@@ -225,6 +237,7 @@ set(ALL_FILES
     ${Header_Files__include}
     ${soh__}
     ${soh__Enhancements}
+    ${soh__Extractor}
     ${soh__Resource}
     ${src__}
 )
@@ -478,8 +491,7 @@ if(MSVC)
                 /FORCE:MULTIPLE
             >
             /DEBUG;
-            /SUBSYSTEM:WINDOWS    
-			/MAP:soh.map
+            /SUBSYSTEM:WINDOWS
         )
     elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
         target_link_options(${PROJECT_NAME} PRIVATE
@@ -594,7 +606,6 @@ endif()
 # Pre build events
 ################################################################################
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-	set(ZAPD_LIB TRUE)
 	add_custom_command_if(
 		TARGET ${PROJECT_NAME}
 		PRE_BUILD
@@ -608,7 +619,7 @@ endif()
 add_dependencies(${PROJECT_NAME}
     ZAPDUtils
     libultraship
-	ZAPD
+	ZAPDLib
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -616,7 +627,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		set(ADDITIONAL_LIBRARY_DEPENDENCIES
 			"libultraship;"
 			"ZAPDUtils;"
-			"ZAPD"
+			"ZAPDLib;"
 			"glu32;"
 			"SDL2::SDL2;"
 			"SDL2::SDL2main;"
@@ -631,7 +642,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		set(ADDITIONAL_LIBRARY_DEPENDENCIES
 			"libultraship;"
 			"ZAPDUtils;"
-			"ZAPD"
+			"ZAPDLib;"
 			"glu32;"
 			"SDL2::SDL2;"
 			"SDL2::SDL2main;"


### PR DESCRIPTION
Splits zapd into a library target and adds a small wrapper to create an executable target