### PR TITLE
fix working dir and copy xmls on build

### DIFF
--- a/ZAPDTR/ZAPD/CMakeLists.txt
+++ b/ZAPDTR/ZAPD/CMakeLists.txt
@@ -290,7 +290,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		)
 	endif()
 elseif (CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin")
-        set_target_properties(${PROJECT_NAME} PROPERTIES
+        set_target_properties(ZAPD PROPERTIES
 		OUTPUT_NAME "ZAPD.out"
 	)
 endif()
@@ -414,7 +414,7 @@ if(MSVC)
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
-	target_compile_options(${PROJECT_NAME} PRIVATE
+	target_compile_options(${PROJECT_NAME} PUBLIC
 		-Wall -Wextra -Wno-error
         -Wno-unused-parameter
         -Wno-unused-function
@@ -427,11 +427,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
 	)
 	
     if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        target_link_options(${PROJECT_NAME} PRIVATE
+        target_link_options(${PROJECT_NAME} PUBLIC
             -pthread
         )
     else()
-        target_link_options(${PROJECT_NAME} PRIVATE
+        target_link_options(${PROJECT_NAME} PUBLIC
             -pthread
             -Wl,-export-dynamic
         )
@@ -501,7 +501,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
 add_library(pathconf OBJECT pathconf.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE "${ADDITIONAL_LIBRARY_DEPENDENCIES}" $<TARGET_OBJECTS:pathconf> )
+target_link_libraries(${PROJECT_NAME} PUBLIC "${ADDITIONAL_LIBRARY_DEPENDENCIES}" $<TARGET_OBJECTS:pathconf> )
 else()
-target_link_libraries(${PROJECT_NAME} PRIVATE "${ADDITIONAL_LIBRARY_DEPENDENCIES}")
+target_link_libraries(${PROJECT_NAME} PUBLIC "${ADDITIONAL_LIBRARY_DEPENDENCIES}")
 endif()

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -612,6 +612,14 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		COMMANDS
 		COMMAND   $<CONFIG:Debug> copy /b $<SHELL_PATH:${CMAKE_BINARY_DIR}/>build.c +,,
 	)
+	add_custom_command(
+		TARGET ${PROJECT_NAME}
+		POST_BUILD
+		COMMENT "Copying asset xmls..."
+		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/OTRGui/assets $<TARGET_FILE_DIR:soh>/assets
+		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/soh/assets/xml $<TARGET_FILE_DIR:soh>/assets/extractor/xmls
+		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/OTRExporter/assets $<TARGET_FILE_DIR:soh>/Extract/assets
+	)
 endif()
 ################################################################################
 # Dependencies

--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -243,7 +243,7 @@ bool Extractor::GetRomPathFromBox() {
     box.lpstrFile = nameBuffer;
     box.nMaxFile = sizeof(nameBuffer) / sizeof(nameBuffer[0]);
     box.lpstrTitle = "Open Rom";
-    box.Flags = OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_LONGNAMES | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
+    box.Flags = OFN_NOCHANGEDIR | OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_LONGNAMES | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
     box.lpstrFilter = "N64 Roms\0*.z64;*.v64;*.n64\0\0";
     if (!GetOpenFileNameA(&box)) {
         DWORD err = CommDlgExtendedError();


### PR DESCRIPTION
This prevents the file dialog box from changing the working dir via the OFN_NOCHANGEDIR flag
Add a post build command to copy the required asset xmls to the appropriate places in the target dir folder